### PR TITLE
Add __arm__ and __aarch64__ wherever __x86_64__ is

### DIFF
--- a/include/lyrscfg.h
+++ b/include/lyrscfg.h
@@ -27,7 +27,7 @@
 #endif
 
 
-#if (vax || i386 || __x86_64__)
+#if (vax || i386 || __x86_64__ || __arm__ || __aarch64__)
 #define USE_LITTLEENDIAN	/* host is little endian byte order */
 #endif
 
@@ -41,7 +41,7 @@
  *  in the "#if".
  */
 
-#if (i386 || __x86_64__ || mips || hppa || u3b2 || u3b || uts || pyr || vax || alliant)
+#if (i386 || __x86_64__ || __arm__ || __aarch64__ || mips || hppa || u3b2 || u3b || uts || pyr || vax || alliant)
 
 #define USE_NAMED_PIPE		/* use named pipes instead of sockets */
 
@@ -57,13 +57,13 @@
 
 #ifndef NO_SYSVLIKE
 
-#if (i386 || __x86_64__ || mips || hppa || u3b2 || u3b || uts || pyr || vax || alliant)
+#if (i386 || __x86_64__ || __arm__ || __aarch64__ || mips || hppa || u3b2 || u3b || uts || pyr || vax || alliant)
 #ifndef USE_SYSVLIKE
 #define USE_SYSVLIKE
 #endif
 #endif
 
-#if (i386 || __x86_64__)
+#if (i386 || __x86_64__ || __arm__ || __aarch64__)
 #if (!defined(USE_SYSVR4LIKE) && !defined(NO_SYSVR4LIKE))
 #define USE_SYSVR4LIKE
 #endif
@@ -164,7 +164,7 @@
 #define USE_ALT_PTYALLOC
 #endif
 
-#if (u3b2 || i386 || __x86_64__)
+#if (u3b2 || i386 || __x86_64__ || __arm__ || __aarch64__)
 #define USE_PTEM		/* include sys/ptem.h to get struct winsize */
 #endif
 


### PR DESCRIPTION
Supports ARM-based Linux such as on the Raspberry Pi